### PR TITLE
Fixed time functions to work also on MacOS/FreeBSD.

### DIFF
--- a/include/wb.h
+++ b/include/wb.h
@@ -281,7 +281,11 @@ namespace CudaTimerNS
         }
     };
 #else
-    #include <time.h>
+    #if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+        #include<time.h>
+    #else
+        #include<sys/time.h>
+    #endif
 
     class CudaTimer
     {
@@ -289,29 +293,37 @@ namespace CudaTimerNS
         long long _start;
         long long _end;
 
+	long long get_time() {
+	    long long time;
+	    #if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0
+                struct timestamp ts;
+                if (0 == clock_gettime(CLOCK_REALTIME,&ts))
+                {
+                    time  = 1000000000LL; // seconds->nanonseconds
+                    time *= ts.tv_sec;
+		    time += ts.tv_nsec;
+                }
+	    #else
+                struct timeval tv;
+                if (0 == gettimeofday(&tv, NULL))
+                {
+		    time  = 1000000000LL; // seconds->nanonseconds
+		    time *= tv.tv_sec;
+		    time += tv.tv_usec * 1000; // ms->ns
+                }
+            #endif
+	  return time;
+      }
+
     public:
         void start()
         {
-            struct timespec sp;
-
-            if (0 == clock_gettime(CLOCK_REALTIME,&sp))
-            {
-                _start  = 1000000000LL; // seconds->nanonseconds
-                _start *= sp.tv_sec;
-                _start += sp.tv_nsec;
-            }
+            _start = get_time();
         }
 
         void stop()
         {
-            struct timespec sp;
-
-            if (0 == clock_gettime(CLOCK_REALTIME,&sp))
-            {
-                _end  = 1000000000LL; // seconds->nanonseconds
-                _end *= sp.tv_sec;
-                _end += sp.tv_nsec;
-            }
+            _end = get_time();
         }
 
         double value()


### PR DESCRIPTION
Fixed time functions to work also on MacOS/FreeBSD.

No nanosecond precision supported for MacOS/FreeBSD, for more info see:

http://laclefyoshi.blogspot.com/2011/05/getting-nanoseconds-in-c-on-freebsd.ht
http://www.wanderinghill.com/wp/?p=29
